### PR TITLE
export ~/.uve/envname path to UV_PROJECT_ENVIRONMENT env variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,8 +110,9 @@ $env:PATH = "%s\Scripts;" + $env:PATH
 	}
 	return fmt.Sprintf(`export UVE_OLD_PATH="$PATH"
 export VIRTUAL_ENV="%s"
+export UV_PROJECT_ENVIRONMENT="%s"
 export PATH="%s/bin:$PATH"
-`, envPath, envPath)
+`, envPath, envPath, envPath)
 }
 
 // generateDeactivateScript generates a shell script to deactivate the current virtual environment.


### PR DESCRIPTION
Hey Robert!
Appreciate the work you've done, i found uve very useful.

## Issue
After creating a env, when i got go my project folder and run uv sync, i'm getting this error message:
`warning: `VIRTUAL_ENV=/Users/vmatt/.uve/py312` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead`

Then uv  proceeds by creating a .venv folder in the working directory, instead of using the existing venv created via uve in the ~/.uve/ path! 

What I found that I must export [UV_PROJECT_ENVIRONMENT](https://docs.astral.sh/uv/configuration/environment/) as a env variable when activating the environment, then uv will respect the path where the environment was already created.

## System environment
- MacOS 15.3.1
- uv 0.6.3